### PR TITLE
do not enforce springboot version, let the application decide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.1] - 2022-02-01
+
+* Stop enforcing springboot platform
+
 ## [2.7.0] - 2021-06-11
 
 * Migrating CI to Github Actions.

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -24,10 +24,10 @@ repositories {
 }
 
 dependencies {
-    annotationProcessor(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}!!"))
-    compileOnly(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}!!"))
-    implementation(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}!!"))
-    testAnnotationProcessor(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}!!"))
+    annotationProcessor(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))
+    compileOnly(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))
+    implementation(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))
+    testAnnotationProcessor(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))
 
     annotationProcessor("org.projectlombok:lombok")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=2.7.0
+version=2.7.1
 systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
## Context

We start to move towards springboot 2.6, don't enforce springboot platform in the lib, let the service decide.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
