### PR TITLE
Update mariadb test container to 10.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - ubuntu-latest
     services:
       mariadb:
-        image: mariadb:10.4
+        image: mariadb:10.6
         ports:
           - 3306:3306
         env:


### PR DESCRIPTION
## Context

MariaDB 10.4 is no longer being used, so a bump in the MariaDB test container is required.

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
