### PR TITLE
Fixed hardcoded versions into POM.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.1] - 2023-03-16
+
+### Fixed
+
+* Hardcoding versions coming from BOMs into POM.
+  That way older dependency resolvers can work without issues as well.
+  Overall this is the most correct way to generate the POM.
+
+### Changed
+
+* When SQL parsing fails, we will also add entrypoint dimension into the failure metric, to make it clearer where a
+  problematic SQL may come from.
+
+* Refactored metrics' constants to a form easily copyable to Grafana.
+
 ## [2.8.0] - 2023-02-14
 
 ### Changed

--- a/build.publishing.gradle
+++ b/build.publishing.gradle
@@ -15,6 +15,19 @@ publishing {
                 artifactId = projectArtifactName
             }
 
+            /*
+             This ensures that libraries will have explicit dependency versions in their Maven POM and Gradle module files, so that there would be less
+             ambiguity and less chances of dependency conflicts.
+            */
+            versionMapping {
+                usage('java-api') {
+                    fromResolutionOf('runtimeClasspath')
+                }
+                usage('java-runtime') {
+                    fromResolutionOf('runtimeClasspath')
+                }
+            }
+
             pom {
                 name = projectName
                 description = projectDescription

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.8.0
+version=2.8.1

--- a/tw-entrypoints-starter/src/test/java/com/transferwise/common/entrypoints/databaseaccessstatistics/DatabaseAccessStatisticsIntTest.java
+++ b/tw-entrypoints-starter/src/test/java/com/transferwise/common/entrypoints/databaseaccessstatistics/DatabaseAccessStatisticsIntTest.java
@@ -39,21 +39,21 @@ public class DatabaseAccessStatisticsIntTest extends BaseIntTest {
 
     Map<String, Meter> meters = metersAsMap();
 
-    assertThat(((DistributionSummary) meters.get("Registered.NTQueries")).count()).isEqualTo(1);
-    assertThat(((DistributionSummary) meters.get("Registered.NTQueries")).mean()).isEqualTo(1);
-    assertThat(meters.get("Registered.NTQueries").getId().getTag("db")).isEqualTo("mydb");
-    assertThat(((DistributionSummary) meters.get("Registered.TQueries")).mean()).isEqualTo(0);
-    assertThat(((DistributionSummary) meters.get("Registered.MaxConcurrentConnections")).mean()).isEqualTo(1);
-    assertThat(((DistributionSummary) meters.get("Registered.RemainingOpenConnections")).mean()).isEqualTo(0);
-    assertThat(((Timer) meters.get("Registered.TimeTaken")).mean(TimeUnit.NANOSECONDS)).isGreaterThan(0);
-    assertThat(((DistributionSummary) meters.get("Registered.Commits")).mean()).isEqualTo(0);
-    assertThat(((DistributionSummary) meters.get("Registered.Rollbacks")).mean()).isEqualTo(0);
-    assertThat(((DistributionSummary) meters.get("Registered.AffectedRows")).count()).isEqualTo(1);
-    assertThat(((DistributionSummary) meters.get("Registered.FetchedRows")).count()).isEqualTo(1);
+    assertThat(((DistributionSummary) meters.get("Registered_NTQueries")).count()).isEqualTo(1);
+    assertThat(((DistributionSummary) meters.get("Registered_NTQueries")).mean()).isEqualTo(1);
+    assertThat(meters.get("Registered_NTQueries").getId().getTag("db")).isEqualTo("mydb");
+    assertThat(((DistributionSummary) meters.get("Registered_TQueries")).mean()).isEqualTo(0);
+    assertThat(((DistributionSummary) meters.get("Registered_MaxConcurrentConnections")).mean()).isEqualTo(1);
+    assertThat(((DistributionSummary) meters.get("Registered_RemainingOpenConnections")).mean()).isEqualTo(0);
+    assertThat(((Timer) meters.get("Registered_TimeTaken")).mean(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+    assertThat(((DistributionSummary) meters.get("Registered_Commits")).mean()).isEqualTo(0);
+    assertThat(((DistributionSummary) meters.get("Registered_Rollbacks")).mean()).isEqualTo(0);
+    assertThat(((DistributionSummary) meters.get("Registered_AffectedRows")).count()).isEqualTo(1);
+    assertThat(((DistributionSummary) meters.get("Registered_FetchedRows")).count()).isEqualTo(1);
 
-    assertThat(((Counter) meters.get("Unknown.Commits")).count()).isEqualTo(0);
-    assertThat(((Counter) meters.get("Unknown.NTQueries")).count()).isEqualTo(0);
-    assertThat(((Counter) meters.get("Unknown.TQueries")).count()).isEqualTo(0);
+    assertThat(((Counter) meters.get("Unknown_Commits")).count()).isEqualTo(0);
+    assertThat(((Counter) meters.get("Unknown_NTQueries")).count()).isEqualTo(0);
+    assertThat(((Counter) meters.get("Unknown_TQueries")).count()).isEqualTo(0);
   }
 
   @Test
@@ -65,12 +65,12 @@ public class DatabaseAccessStatisticsIntTest extends BaseIntTest {
     });
 
     Map<String, Meter> meters = metersAsMap();
-    assertThat(meters.get("Registered.NTQueries")).isNull();
-    assertThat(((Counter) meters.get("Unknown.Commits")).count()).isEqualTo(0);
-    assertThat(((Counter) meters.get("Unknown.NTQueries")).count()).isEqualTo(1);
-    assertThat(((Counter) meters.get("Unknown.TQueries")).count()).isEqualTo(0);
-    assertThat(((Counter) meters.get("Unknown.AffectedRows")).count()).isEqualTo(0);
-    assertThat(((Counter) meters.get("Unknown.FetchedRows")).count()).isEqualTo(0);
+    assertThat(meters.get("Registered_NTQueries")).isNull();
+    assertThat(((Counter) meters.get("Unknown_Commits")).count()).isEqualTo(0);
+    assertThat(((Counter) meters.get("Unknown_NTQueries")).count()).isEqualTo(1);
+    assertThat(((Counter) meters.get("Unknown_TQueries")).count()).isEqualTo(0);
+    assertThat(((Counter) meters.get("Unknown_AffectedRows")).count()).isEqualTo(0);
+    assertThat(((Counter) meters.get("Unknown_FetchedRows")).count()).isEqualTo(0);
   }
 
   @Test
@@ -89,16 +89,16 @@ public class DatabaseAccessStatisticsIntTest extends BaseIntTest {
 
     Map<String, Meter> meters = metersAsMap();
 
-    assertThat(((DistributionSummary) meters.get("Registered.AffectedRows")).count()).isEqualTo(1);
-    assertThat(((DistributionSummary) meters.get("Registered.FetchedRows")).count()).isEqualTo(1);
+    assertThat(((DistributionSummary) meters.get("Registered_AffectedRows")).count()).isEqualTo(1);
+    assertThat(((DistributionSummary) meters.get("Registered_FetchedRows")).count()).isEqualTo(1);
 
-    assertThat(((DistributionSummary) meters.get("Registered.AffectedRows")).totalAmount()).isEqualTo(31 + 7 + 5);
-    assertThat(((DistributionSummary) meters.get("Registered.FetchedRows")).totalAmount()).isEqualTo(31 - 5);
+    assertThat(((DistributionSummary) meters.get("Registered_AffectedRows")).totalAmount()).isEqualTo(31 + 7 + 5);
+    assertThat(((DistributionSummary) meters.get("Registered_FetchedRows")).totalAmount()).isEqualTo(31 - 5);
 
   }
 
   private Map<String, Meter> metersAsMap() {
-    return meterRegistry.getMeters().stream().filter(m -> m.getId().getName().startsWith("EntryPoints.Das")).collect(Collectors
-        .toMap(m -> StringUtils.substringAfter(m.getId().getName(), "EntryPoints.Das."), m -> m));
+    return meterRegistry.getMeters().stream().filter(m -> m.getId().getName().startsWith("EntryPoints_Das")).collect(Collectors
+        .toMap(m -> StringUtils.substringAfter(m.getId().getName(), "EntryPoints_Das_"), m -> m));
   }
 }

--- a/tw-entrypoints-starter/src/test/java/com/transferwise/common/entrypoints/executionstatistics/ExecutionStatisticIntTest.java
+++ b/tw-entrypoints-starter/src/test/java/com/transferwise/common/entrypoints/executionstatistics/ExecutionStatisticIntTest.java
@@ -19,7 +19,7 @@ public class ExecutionStatisticIntTest extends BaseIntTest {
   void executionStatisticsAreGathered() {
     TwContext.current().createSubContext().asEntryPoint("Test", "myEntryPoint").execute(() -> log.info("I'm inside an entrypoint!"));
 
-    List<Meter> meters = meterRegistry.getMeters().stream().filter(m -> m.getId().getName().equals("EntryPoints.Es.timeTaken"))
+    List<Meter> meters = meterRegistry.getMeters().stream().filter(m -> m.getId().getName().equals("EntryPoints_Es_timeTaken"))
         .collect(Collectors.toList());
 
     assertThat(meters.size()).isEqualTo(1);
@@ -34,7 +34,7 @@ public class ExecutionStatisticIntTest extends BaseIntTest {
       throw new RuntimeException("Something went wrong.");
     }));
 
-    List<Meter> meters = meterRegistry.getMeters().stream().filter(m -> m.getId().getName().equals("EntryPoints.Es.timeTaken"))
+    List<Meter> meters = meterRegistry.getMeters().stream().filter(m -> m.getId().getName().equals("EntryPoints_Es_timeTaken"))
         .collect(Collectors.toList());
 
     assertThat(meters.size()).isEqualTo(1);

--- a/tw-entrypoints-starter/src/test/java/com/transferwise/common/entrypoints/tableaccessstatistics/TableAccessStatisticsIntTest.java
+++ b/tw-entrypoints-starter/src/test/java/com/transferwise/common/entrypoints/tableaccessstatistics/TableAccessStatisticsIntTest.java
@@ -56,7 +56,7 @@ public class TableAccessStatisticsIntTest extends BaseIntTest {
     assertThat(counter.getId().getTag("epGroup")).isEqualTo("Test");
     assertThat(counter.count()).isEqualTo(1);
 
-    var firstTableAccessMeter = (Timer) getMeter("EntryPoints.Tas.FirstTableAccess");
+    var firstTableAccessMeter = (Timer) getMeter("EntryPoints_Tas_FirstTableAccess");
 
     assertThat(firstTableAccessMeter).isNotNull();
     assertThat(firstTableAccessMeter.getId().getTag("success")).isEqualTo("false");
@@ -118,7 +118,7 @@ public class TableAccessStatisticsIntTest extends BaseIntTest {
     assertThat(meters.size()).isEqualTo(1);
     assertThat(((Counter) meters.get(0)).count()).isEqualTo(3);
 
-    assertThat(((Gauge) getMeter("EntryPoints.Tas.SqlParseResultsCache.size")).value()).isEqualTo(1);
+    assertThat(((Gauge) getMeter("EntryPoints_Tas_SqlParseResultsCache_size")).value()).isEqualTo(1);
   }
 
   private Meter getMeter(String name) {
@@ -127,7 +127,7 @@ public class TableAccessStatisticsIntTest extends BaseIntTest {
   }
 
   private List<Meter> getTableAccessMeters() {
-    return meterRegistry.getMeters().stream().filter(m -> m.getId().getName().equals("EntryPoints.Tas.TableAccess"))
+    return meterRegistry.getMeters().stream().filter(m -> m.getId().getName().equals("EntryPoints_Tas_TableAccess"))
         .collect(Collectors.toList());
   }
 

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/databaseaccessstatistics/DatabaseAccessStatisticsEntryPointInterceptor.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/databaseaccessstatistics/DatabaseAccessStatisticsEntryPointInterceptor.java
@@ -1,7 +1,5 @@
 package com.transferwise.common.entrypoints.databaseaccessstatistics;
 
-import static com.transferwise.common.entrypoints.EntryPointsMetrics.METRIC_PREFIX_ENTRYPOINTS;
-
 import com.transferwise.common.baseutils.meters.cache.IMeterCache;
 import com.transferwise.common.baseutils.meters.cache.TagsSet;
 import com.transferwise.common.context.TwContext;
@@ -21,29 +19,27 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DatabaseAccessStatisticsEntryPointInterceptor implements TwContextExecutionInterceptor {
 
-  public static final String METRIC_PREFIX_DAS = METRIC_PREFIX_ENTRYPOINTS + "Das.";
+  public static final String METRIC_PREFIX_DAS = "EntryPoints_Das_";
 
-  public static final String METRIC_PREFIX_DAS_REGISTERED = METRIC_PREFIX_DAS + "Registered.";
-  public static final String METRIC_REGISTERED_TIME_TAKEN = METRIC_PREFIX_DAS_REGISTERED + "TimeTaken";
-  public static final String METRIC_REGISTERED_FETCHED_ROWS = METRIC_PREFIX_DAS_REGISTERED + "FetchedRows";
-  public static final String METRIC_REGISTERED_AFFECTED_ROWS = METRIC_PREFIX_DAS_REGISTERED + "AffectedRows";
-  public static final String METRIC_REGISTERED_EMPTY_TRANSACTIONS = METRIC_PREFIX_DAS_REGISTERED + "EmptyTransactions";
-  public static final String METRIC_REGISTERED_REMAINING_OPEN_CONNECTIONS = METRIC_PREFIX_DAS_REGISTERED + "RemainingOpenConnections";
-  public static final String METRIC_REGISTERED_MAX_CONCURRENT_CONNECTIONS = METRIC_PREFIX_DAS_REGISTERED + "MaxConcurrentConnections";
-  public static final String METRIC_REGISTERED_T_QUERIES = METRIC_PREFIX_DAS_REGISTERED + "TQueries";
-  public static final String METRIC_REGISTERED_NT_QUERIES = METRIC_PREFIX_DAS_REGISTERED + "NTQueries";
-  public static final String METRIC_REGISTERED_ROLLBACKS = METRIC_PREFIX_DAS_REGISTERED + "Rollbacks";
-  public static final String METRIC_REGISTERED_COMMITS = METRIC_PREFIX_DAS_REGISTERED + "Commits";
+  public static final String TIMER_REGISTERED_TIME_TAKEN = "EntryPoints_Das_Registered_TimeTaken";
+  public static final String SUMMARY_REGISTERED_FETCHED_ROWS = "EntryPoints_Das_Registered_FetchedRows";
+  public static final String SUMMARY_REGISTERED_AFFECTED_ROWS = "EntryPoints_Das_Registered_AffectedRows";
+  public static final String SUMMARY_REGISTERED_EMPTY_TRANSACTIONS = "EntryPoints_Das_Registered_EmptyTransactions";
+  public static final String SUMMARY_REGISTERED_REMAINING_OPEN_CONNECTIONS = "EntryPoints_Das_Registered_RemainingOpenConnections";
+  public static final String SUMMARY_REGISTERED_MAX_CONCURRENT_CONNECTIONS = "EntryPoints_Das_Registered_MaxConcurrentConnections";
+  public static final String SUMMARY_REGISTERED_T_QUERIES = "EntryPoints_Das_Registered_TQueries";
+  public static final String SUMMARY_REGISTERED_NT_QUERIES = "EntryPoints_Das_Registered_NTQueries";
+  public static final String SUMMARY_REGISTERED_ROLLBACKS = "EntryPoints_Das_Registered_Rollbacks";
+  public static final String SUMMARY_REGISTERED_COMMITS = "EntryPoints_Das_Registered_Commits";
 
-  public static final String METRIC_PREFIX_DAS_UNREGISTERED = METRIC_PREFIX_DAS + "Unknown.";
-  public static final String METRIC_UNREGISTERED_FETCHED_ROWS = METRIC_PREFIX_DAS_UNREGISTERED + "FetchedRows";
-  public static final String METRIC_UNREGISTERED_AFFECTED_ROWS = METRIC_PREFIX_DAS_UNREGISTERED + "AffectedRows";
-  public static final String METRIC_UNREGISTERED_EMPTY_TRANSACTIONS = METRIC_PREFIX_DAS_UNREGISTERED + "EmptyTransactions";
-  public static final String METRIC_UNREGISTERED_TIME_TAKEN_NS = METRIC_PREFIX_DAS_UNREGISTERED + "TimeTakenNs";
-  public static final String METRIC_UNREGISTERED_T_QUERIES = METRIC_PREFIX_DAS_UNREGISTERED + "TQueries";
-  public static final String METRIC_UNREGISTERED_NT_QUERIES = METRIC_PREFIX_DAS_UNREGISTERED + "NTQueries";
-  public static final String METRIC_UNREGISTERED_ROLLBACKS = METRIC_PREFIX_DAS_UNREGISTERED + "Rollbacks";
-  public static final String METRIC_UNREGISTERED_COMMITS = METRIC_PREFIX_DAS_UNREGISTERED + "Commits";
+  public static final String COUNTER_UNREGISTERED_FETCHED_ROWS = "EntryPoints_Das_Unknown_FetchedRows";
+  public static final String COUNTER_UNREGISTERED_AFFECTED_ROWS = "EntryPoints_Das_Unknown_AffectedRows";
+  public static final String COUNTER_UNREGISTERED_EMPTY_TRANSACTIONS = "EntryPoints_Das_Unknown_EmptyTransactions";
+  public static final String COUNTER_UNREGISTERED_TIME_TAKEN_NS = "EntryPoints_Das_Unknown_TimeTakenNs";
+  public static final String COUNTER_UNREGISTERED_T_QUERIES = "EntryPoints_Das_Unknown_TQueries";
+  public static final String COUNTER_UNREGISTERED_NT_QUERIES = "EntryPoints_Das_Unknown_NTQueries";
+  public static final String COUNTER_UNREGISTERED_ROLLBACKS = "EntryPoints_Das_Unknown_Rollbacks";
+  public static final String COUNTER_UNREGISTERED_COMMITS = "EntryPoints_Das_Unknown_Commits";
 
   private final IMeterCache meterCache;
 
@@ -89,16 +85,16 @@ public class DatabaseAccessStatisticsEntryPointInterceptor implements TwContextE
 
       CallMeters meters = meterCache.metersContainer(METRIC_PREFIX_DAS + "callMetrics", tagsSet, () -> {
         CallMeters result = new CallMeters();
-        result.commits = meterCache.summary(METRIC_REGISTERED_COMMITS, tagsSet);
-        result.rollbacks = meterCache.summary(METRIC_REGISTERED_ROLLBACKS, tagsSet);
-        result.nonTransactionalQueries = meterCache.summary(METRIC_REGISTERED_NT_QUERIES, tagsSet);
-        result.transactionalQueries = meterCache.summary(METRIC_REGISTERED_T_QUERIES, tagsSet);
-        result.maxConcurrentConnections = meterCache.summary(METRIC_REGISTERED_MAX_CONCURRENT_CONNECTIONS, tagsSet);
-        result.remainingOpenConnections = meterCache.summary(METRIC_REGISTERED_REMAINING_OPEN_CONNECTIONS, tagsSet);
-        result.emptyTransactions = meterCache.summary(METRIC_REGISTERED_EMPTY_TRANSACTIONS, tagsSet);
-        result.affectedRows = meterCache.summary(METRIC_REGISTERED_AFFECTED_ROWS, tagsSet);
-        result.fetchedRows = meterCache.summary(METRIC_REGISTERED_FETCHED_ROWS, tagsSet);
-        result.timeTakenNs = meterCache.timer(METRIC_REGISTERED_TIME_TAKEN, tagsSet);
+        result.commits = meterCache.summary(SUMMARY_REGISTERED_COMMITS, tagsSet);
+        result.rollbacks = meterCache.summary(SUMMARY_REGISTERED_ROLLBACKS, tagsSet);
+        result.nonTransactionalQueries = meterCache.summary(SUMMARY_REGISTERED_NT_QUERIES, tagsSet);
+        result.transactionalQueries = meterCache.summary(SUMMARY_REGISTERED_T_QUERIES, tagsSet);
+        result.maxConcurrentConnections = meterCache.summary(SUMMARY_REGISTERED_MAX_CONCURRENT_CONNECTIONS, tagsSet);
+        result.remainingOpenConnections = meterCache.summary(SUMMARY_REGISTERED_REMAINING_OPEN_CONNECTIONS, tagsSet);
+        result.emptyTransactions = meterCache.summary(SUMMARY_REGISTERED_EMPTY_TRANSACTIONS, tagsSet);
+        result.affectedRows = meterCache.summary(SUMMARY_REGISTERED_AFFECTED_ROWS, tagsSet);
+        result.fetchedRows = meterCache.summary(SUMMARY_REGISTERED_FETCHED_ROWS, tagsSet);
+        result.timeTakenNs = meterCache.timer(TIMER_REGISTERED_TIME_TAKEN, tagsSet);
         return result;
       });
 
@@ -151,14 +147,14 @@ public class DatabaseAccessStatisticsEntryPointInterceptor implements TwContextE
       TagsSet tagsSet = das.getTagsSet();
       UnknownCallMeters meters = meterCache.metersContainer(METRIC_PREFIX_DAS + "unknownCallMetrics", tagsSet, () -> {
         UnknownCallMeters result = new UnknownCallMeters();
-        result.commits = meterCache.counter(METRIC_UNREGISTERED_COMMITS, tagsSet);
-        result.rollbacks = meterCache.counter(METRIC_UNREGISTERED_ROLLBACKS, tagsSet);
-        result.nonTransactionalQueries = meterCache.counter(METRIC_UNREGISTERED_NT_QUERIES, tagsSet);
-        result.transactionalQueries = meterCache.counter(METRIC_UNREGISTERED_T_QUERIES, tagsSet);
-        result.timeTakenNs = meterCache.counter(METRIC_UNREGISTERED_TIME_TAKEN_NS, tagsSet);
-        result.emptyTransactions = meterCache.counter(METRIC_UNREGISTERED_EMPTY_TRANSACTIONS, tagsSet);
-        result.affectedRows = meterCache.counter(METRIC_UNREGISTERED_AFFECTED_ROWS, tagsSet);
-        result.fetchedRows = meterCache.counter(METRIC_UNREGISTERED_FETCHED_ROWS, tagsSet);
+        result.commits = meterCache.counter(COUNTER_UNREGISTERED_COMMITS, tagsSet);
+        result.rollbacks = meterCache.counter(COUNTER_UNREGISTERED_ROLLBACKS, tagsSet);
+        result.nonTransactionalQueries = meterCache.counter(COUNTER_UNREGISTERED_NT_QUERIES, tagsSet);
+        result.transactionalQueries = meterCache.counter(COUNTER_UNREGISTERED_T_QUERIES, tagsSet);
+        result.timeTakenNs = meterCache.counter(COUNTER_UNREGISTERED_TIME_TAKEN_NS, tagsSet);
+        result.emptyTransactions = meterCache.counter(COUNTER_UNREGISTERED_EMPTY_TRANSACTIONS, tagsSet);
+        result.affectedRows = meterCache.counter(COUNTER_UNREGISTERED_AFFECTED_ROWS, tagsSet);
+        result.fetchedRows = meterCache.counter(COUNTER_UNREGISTERED_FETCHED_ROWS, tagsSet);
         return result;
       });
 

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/executionstatistics/ExecutionStatisticsEntryPointInterceptor.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/executionstatistics/ExecutionStatisticsEntryPointInterceptor.java
@@ -1,7 +1,5 @@
 package com.transferwise.common.entrypoints.executionstatistics;
 
-import static com.transferwise.common.entrypoints.EntryPointsMetrics.METRIC_PREFIX_ENTRYPOINTS;
-
 import com.transferwise.common.baseutils.clock.ClockHolder;
 import com.transferwise.common.baseutils.meters.cache.IMeterCache;
 import com.transferwise.common.baseutils.meters.cache.TagsSet;
@@ -13,8 +11,8 @@ import java.util.function.Supplier;
 
 public class ExecutionStatisticsEntryPointInterceptor implements TwContextExecutionInterceptor {
 
-  public static final String METRIC_PREFIX_ENTRYPOINTS_ES = METRIC_PREFIX_ENTRYPOINTS + "Es.";
-  public static final String METRIC_TIME_TAKEN = METRIC_PREFIX_ENTRYPOINTS_ES + "timeTaken";
+  public static final String METRIC_PREFIX_ENTRYPOINTS_ES = "EntryPoints_Es_";
+  public static final String TIMER_TIME_TAKEN = "EntryPoints_Es_timeTaken";
 
   private final IMeterCache meterCache;
 
@@ -39,7 +37,7 @@ public class ExecutionStatisticsEntryPointInterceptor implements TwContextExecut
           TwContextMetricsTemplate.TAG_EP_NAME, twContext.getName(),
           TwContextMetricsTemplate.TAG_EP_OWNER, twContext.getOwner());
 
-      meterCache.timer(METRIC_TIME_TAKEN, tagsSet).record(ClockHolder.getClock().millis() - startTimeMs, TimeUnit.MILLISECONDS);
+      meterCache.timer(TIMER_TIME_TAKEN, tagsSet).record(ClockHolder.getClock().millis() - startTimeMs, TimeUnit.MILLISECONDS);
     }
   }
 }

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/TasMeterFilter.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/TasMeterFilter.java
@@ -1,7 +1,7 @@
 package com.transferwise.common.entrypoints.tableaccessstatistics;
 
 import static com.transferwise.common.entrypoints.EntryPointsMetrics.MS_TO_NS;
-import static com.transferwise.common.entrypoints.tableaccessstatistics.TableAccessStatisticsSpyqlListener.METRIC_FIRST_TABLE_ACCESS;
+import static com.transferwise.common.entrypoints.tableaccessstatistics.TableAccessStatisticsSpyqlListener.TIMER_FIRST_TABLE_ACCESS;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.config.MeterFilter;
@@ -11,7 +11,7 @@ public class TasMeterFilter implements MeterFilter {
 
   @Override
   public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
-    if (METRIC_FIRST_TABLE_ACCESS.equals(id.getName())) {
+    if (TIMER_FIRST_TABLE_ACCESS.equals(id.getName())) {
       return DistributionStatisticConfig.builder()
           .percentilesHistogram(false)
           .serviceLevelObjectives(MS_TO_NS, 5 * MS_TO_NS, 25 * MS_TO_NS, 125 * MS_TO_NS, 625 * MS_TO_NS, 3125 * MS_TO_NS, 3125 * 5 * MS_TO_NS)

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/transactionstatistics/TransactionsStatisticsSpyqlListener.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/transactionstatistics/TransactionsStatisticsSpyqlListener.java
@@ -33,16 +33,16 @@ public class TransactionsStatisticsSpyqlListener implements SpyqlDataSourceListe
   /**
    * How long did the whole transaction take.
    */
-  public static final String METRIC_TRANSACTION_COMPLETION = "database.transaction.completion";
+  public static final String METRIC_TRANSACTION_COMPLETION = "database_transaction_completion";
 
-  public static final String METRIC_TRANSACTION_START = "database.transaction.start";
+  public static final String METRIC_TRANSACTION_START = "database_transaction_start";
 
   /**
    * How long did only the commit/rollback operation take.
    */
-  public static final String METRIC_TRANSACTION_FINALIZATION = "database.transaction.finalization";
+  public static final String METRIC_TRANSACTION_FINALIZATION = "database_transaction_finalization";
 
-  public static final String METRIC_COLLECTION_TRANSACTION_END = "database.transaction.end";
+  public static final String METRIC_COLLECTION_TRANSACTION_END = "database_transaction_end";
 
   private static final Tag TAG_READ_ONLY_TRUE = Tag.of(TAG_READ_ONLY, "true");
   private static final Tag TAG_READ_ONLY_FALSE = Tag.of(TAG_READ_ONLY, "false");


### PR DESCRIPTION
## Context

### Fixed

* Hardcoding versions coming from BOMs into POM.
  That way older dependency resolvers can work without issues as well.
  Overall this is the most correct way to generate the POM.

### Changed

* When SQL parsing fails, we will also add entrypoint dimension into the failure metric, to make it clearer where a
  problematic SQL may come from.

* Refactored metrics' constants to a form easily copyable to Grafana.

-------

Tested locally that POM has indeed hard-coded versions now.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
