### PR TITLE
Table Access - uncounted sqls counter and support for DATABASE() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.2] - 2023-03-16
+
+### Added
+
+* Counter `EntryPoints_Tas_UncountedQueries`, to count how many queries we were not able to parse table information from.
+
+* Table access statistics can parse tables on queries containing `DATABASE()` function.
+
 ## [2.8.1] - 2023-03-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Table access statistics can parse tables on queries containing `DATABASE()` function.
 
+### Fixed
+
+* JSqlParser is utilized in a more optimal way, by not executing the parsing in separate threads.
+
 ## [2.8.1] - 2023-03-16
 
 ### Fixed

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -21,6 +21,7 @@ ext {
             flywayMysql                     : 'org.flywaydb:flyway-mysql',
 
             hikariCp                        : "com.zaxxer:HikariCP",
+            junitJupiter                    : "org.junit.jupiter:junit-jupiter",
             lombok                          : "org.projectlombok:lombok",
             mariadbJavaClient               : "org.mariadb.jdbc:mariadb-java-client",
             micrometerCore                  : "io.micrometer:micrometer-core",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.8.1
+version=2.8.2

--- a/tw-entrypoints/build.gradle
+++ b/tw-entrypoints/build.gradle
@@ -18,4 +18,6 @@ dependencies {
     implementation libraries.twBaseUtils
     implementation libraries.twSpyqlCore
 
+    testImplementation libraries.junitJupiter
+
 }

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/SqlParserUtils.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/SqlParserUtils.java
@@ -19,7 +19,12 @@ public class SqlParserUtils {
       Pattern.LITERAL | Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
 
   public Statements parseToStatements(String sql) throws ParseException {
-    sql = FUNCTION_REPLACEMENT_PATTERN.matcher(sql).replaceAll(Matcher.quoteReplacement("UNSUPPORTED()"));
+    // 99.99% of sqls don't have it, so let's avoid new string creation for those.
+    var matcher = FUNCTION_REPLACEMENT_PATTERN.matcher(sql);
+    if (matcher.find()) {
+      matcher.reset();
+      sql = matcher.replaceAll(Matcher.quoteReplacement("UNSUPPORTED()"));
+    }
 
     /*
       Don't use `CCJSqlParserUtil.parse`, this has an overhead of launching a new executor service and parsing the sql there.

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/SqlParserUtils.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/SqlParserUtils.java
@@ -21,6 +21,9 @@ public class SqlParserUtils {
   public Statements parseToStatements(String sql) throws ParseException {
     sql = FUNCTION_REPLACEMENT_PATTERN.matcher(sql).replaceAll(Matcher.quoteReplacement("UNSUPPORTED()"));
 
+    /*
+      Don't use `CCJSqlParserUtil.parse`, this has an overhead of launching a new executor service and parsing the sql there.
+     */
     CCJSqlParser parser = CCJSqlParserUtil.newParser(sql).withAllowComplexParsing(false);
 
     return parser.Statements();

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/SqlParserUtils.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/SqlParserUtils.java
@@ -1,0 +1,28 @@
+package com.transferwise.common.entrypoints.tableaccessstatistics;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.experimental.UtilityClass;
+import net.sf.jsqlparser.parser.CCJSqlParser;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.parser.ParseException;
+import net.sf.jsqlparser.statement.Statements;
+
+@UtilityClass
+public class SqlParserUtils {
+
+  /*
+    DATABASE is reserved keyword in sql parser, so having DATABASE() in sql will just throw error.
+    DATABASE() is however used by some of our internal libraries for MariaDb.
+   */
+  private static final Pattern FUNCTION_REPLACEMENT_PATTERN = Pattern.compile("DATABASE()",
+      Pattern.LITERAL | Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+
+  public Statements parseToStatements(String sql) throws ParseException {
+    sql = FUNCTION_REPLACEMENT_PATTERN.matcher(sql).replaceAll(Matcher.quoteReplacement("UNSUPPORTED()"));
+
+    CCJSqlParser parser = CCJSqlParserUtil.newParser(sql).withAllowComplexParsing(false);
+
+    return parser.Statements();
+  }
+}

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/SqlParserUtils.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/SqlParserUtils.java
@@ -19,8 +19,9 @@ public class SqlParserUtils {
       Pattern.LITERAL | Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
 
   public Statements parseToStatements(String sql) throws ParseException {
-    // 99.99% of sqls don't have it, so let's avoid new string creation for those.
     var matcher = FUNCTION_REPLACEMENT_PATTERN.matcher(sql);
+
+    // 99.99% of sqls don't have it, so let's avoid new string creation for those.
     if (matcher.find()) {
       matcher.reset();
       sql = matcher.replaceAll(Matcher.quoteReplacement("UNSUPPORTED()"));

--- a/tw-entrypoints/src/test/java/com/transferwise/common/entrypoints/tableaccessstatistics/SqlParserUtilsTest.java
+++ b/tw-entrypoints/src/test/java/com/transferwise/common/entrypoints/tableaccessstatistics/SqlParserUtilsTest.java
@@ -1,0 +1,31 @@
+package com.transferwise.common.entrypoints.tableaccessstatistics;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.SneakyThrows;
+import net.sf.jsqlparser.parser.ParseException;
+import org.junit.jupiter.api.Test;
+
+public class SqlParserUtilsTest {
+
+  @Test
+  @SneakyThrows
+  void testJSqlParser() {
+    List<String> sqls = new ArrayList<>();
+
+    // DATABASE is a keyword for sql parser.
+    sqls.add("select DATABASE()");
+
+    sqls.add("delete tl from tag_links tl, tags t where t.name=? and tl.type=? and tl.tag_ref=? and tl.tag_id = t.id");
+    sqls.add("select table_rows from information_schema.tables where table_schema=DATABASE() and table_name = 'tw_task'");
+
+    for (String sql : sqls) {
+      try {
+        SqlParserUtils.parseToStatements(sql);
+      } catch (ParseException e) {
+        throw new RuntimeException("Failed to parse sql '" + sql + "'.", e);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
## Context

### Added

* Counter `EntryPoints_Tas_UncountedQueries`, to count how many queries we were not able to parse table information from.

* Table access statistics can parse tables on queries containing `DATABASE()` function.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
