### PR TITLE
Bean post processor is returning the correct bean.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.3] - 2023-03-16
+
+### Fixed
+
+* A bug where bean postprocessor was returning a wrong bean - unwrapped spyql datasource.
+
 ## [2.8.2] - 2023-03-16
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.8.2
+version=2.8.3

--- a/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/BaseEntryPointsBeanProcessor.java
+++ b/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/BaseEntryPointsBeanProcessor.java
@@ -22,7 +22,7 @@ public abstract class BaseEntryPointsBeanProcessor implements BeanPostProcessor,
       return bean;
     }
 
-    return ExceptionUtils.doUnchecked(() -> {
+    ExceptionUtils.doUnchecked(() -> {
       var dataSource = (DataSource) bean;
 
       if (!dataSource.isWrapperFor(SpyqlDataSource.class)) {
@@ -30,11 +30,10 @@ public abstract class BaseEntryPointsBeanProcessor implements BeanPostProcessor,
       }
 
       var spyqlDataSource = dataSource.unwrap(SpyqlDataSource.class);
-
       instrument(spyqlDataSource, spyqlDataSource.getDatabaseName());
-
-      return spyqlDataSource;
     });
+
+    return bean;
   }
 
   protected abstract void instrument(SpyqlDataSource spyqlDataSource, String databaseName);


### PR DESCRIPTION
## Context

### Fixed

* A bug where bean postprocessor was returning a wrong bean - unwrapped spyql datasource.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
