### PR TITLE
DAS unknown calls are now collected in a separate thread, once per second.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.0] - 2023-05-03
+
+### Added
+
+* Counter `EntryPoints_Tas_Parses`, to count per entrypoint, how many parses have been done.
+  It allows to identify, which service components are generating most distinct queries and thus bloating the cache or just burning CPU for parses.
+
+### Changed
+
+* DAS for database access done outside of entrypoints are now collected in a separate thread.
+  This would allow to collect those metrics even when the service does not have any entrypoints or they are
+  infrequently accessed.
+
 ## [2.8.3] - 2023-03-16
 
 ### Fixed

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -11,6 +11,8 @@ ext {
             twBaseUtils                     : "com.transferwise.common:tw-base-utils:1.9.0",
             twContext                       : "com.transferwise.common:tw-context:0.11.1",
             twContextStarter                : "com.transferwise.common:tw-context-starter:0.11.1",
+            twGracefulShutdown              : 'com.transferwise.common:tw-graceful-shutdown:2.8.0',
+            twGracefulShutdownInterfaces    : 'com.transferwise.common:tw-graceful-shutdown-interfaces:2.8.0',
             twSpyqlCore                     : "com.transferwise.common:tw-spyql-core:1.5.0",
             twSpyqlStarter                  : "com.transferwise.common:tw-spyql-starter:1.5.0",
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.8.3
+version=2.9.0

--- a/tw-entrypoints-starter/build.gradle
+++ b/tw-entrypoints-starter/build.gradle
@@ -19,11 +19,14 @@ dependencies {
     implementation libraries.twContextStarter
     implementation libraries.twSpyqlStarter
 
+    runtimeOnly libraries.twGracefulShutdown
+
     testImplementation libraries.caffeine
     testImplementation libraries.testContainersMariaDb
     testImplementation libraries.slf4jApi
     testImplementation libraries.springBootStarterJdbc
     testImplementation libraries.springBootStarterTest
+    testImplementation libraries.twGracefulShutdownInterfaces
 
     testRuntimeOnly libraries.flywayCore
     if (springBootVersion.startsWith("2.7")) {

--- a/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/EntryPointsAutoConfiguration.java
+++ b/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/EntryPointsAutoConfiguration.java
@@ -5,6 +5,7 @@ import com.transferwise.common.baseutils.concurrency.IExecutorServicesProvider;
 import com.transferwise.common.baseutils.meters.cache.IMeterCache;
 import com.transferwise.common.baseutils.meters.cache.MeterCache;
 import com.transferwise.common.context.TwContext;
+import com.transferwise.common.entrypoints.databaseaccessstatistics.DasUnknownCallsCollector;
 import com.transferwise.common.entrypoints.databaseaccessstatistics.DatabaseAccessStatisticsBeanPostProcessor;
 import com.transferwise.common.entrypoints.databaseaccessstatistics.DatabaseAccessStatisticsEntryPointInterceptor;
 import com.transferwise.common.entrypoints.executionstatistics.ExecutionStatisticsEntryPointInterceptor;
@@ -74,5 +75,11 @@ public class EntryPointsAutoConfiguration {
   @ConditionalOnMissingBean(IMeterCache.class)
   public IMeterCache twDefaultMeterCache(MeterRegistry meterRegistry) {
     return new MeterCache(meterRegistry);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(DasUnknownCallsCollector.class)
+  public DasUnknownCallsCollector unknownCallsCollector(IExecutorServicesProvider executorServicesProvider, IMeterCache meterCache) {
+    return new DasUnknownCallsCollector(executorServicesProvider, meterCache);
   }
 }

--- a/tw-entrypoints-starter/src/test/java/com/transferwise/common/entrypoints/test/BaseIntTest.java
+++ b/tw-entrypoints-starter/src/test/java/com/transferwise/common/entrypoints/test/BaseIntTest.java
@@ -1,7 +1,6 @@
 package com.transferwise.common.entrypoints.test;
 
 import com.transferwise.common.baseutils.meters.cache.IMeterCache;
-import com.transferwise.common.context.TwContext;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
@@ -37,9 +36,6 @@ public class BaseIntTest {
 
   @BeforeEach
   public void setup() {
-    // Resetting counters from Flyway executions.
-    TwContext.current().createSubContext().asEntryPoint("A", "B").execute(() -> {
-    });
     meterRegistry.getMeters().stream()
         .filter(m -> (m.getId().getName().startsWith("EntryPoints") || m.getId().getName().startsWith("database")) && !(m instanceof Gauge))
         .forEach(m -> {

--- a/tw-entrypoints-starter/src/test/resources/application.yml
+++ b/tw-entrypoints-starter/src/test/resources/application.yml
@@ -7,6 +7,10 @@ tw-entrypoints:
     sql-parser:
       cache-size-mib: 1
 
+tw-graceful-shutdown:
+  clients-reaction-time-ms: 100
+  strategies-check-interval-time-ms: 100
+
 ---
 spring:
   config:

--- a/tw-entrypoints/build.gradle
+++ b/tw-entrypoints/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation libraries.slf4jApi
     implementation libraries.twBaseUtils
     implementation libraries.twSpyqlCore
+    implementation libraries.twGracefulShutdownInterfaces
 
     testImplementation libraries.junitJupiter
 

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/EntryPointsMetrics.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/EntryPointsMetrics.java
@@ -17,7 +17,5 @@ public final class EntryPointsMetrics {
   public static final String TAG_RESOLUTION = "resolution";
   public static final String TAG_RESOLUTION_SUCCESS = "resolutionSuccess";
 
-  public static final String METRIC_PREFIX_ENTRYPOINTS = "EntryPoints.";
-
   public static final long MS_TO_NS = 1_000_000L;
 }

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/databaseaccessstatistics/DasUnknownCallsCollector.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/databaseaccessstatistics/DasUnknownCallsCollector.java
@@ -1,0 +1,103 @@
+package com.transferwise.common.entrypoints.databaseaccessstatistics;
+
+import static com.transferwise.common.entrypoints.databaseaccessstatistics.DatabaseAccessStatisticsEntryPointInterceptor.METRIC_PREFIX_DAS;
+
+import com.transferwise.common.baseutils.concurrency.IExecutorServicesProvider;
+import com.transferwise.common.baseutils.concurrency.ScheduledTaskExecutor.TaskHandle;
+import com.transferwise.common.baseutils.meters.cache.IMeterCache;
+import com.transferwise.common.baseutils.meters.cache.TagsSet;
+import com.transferwise.common.gracefulshutdown.GracefulShutdownStrategy;
+import io.micrometer.core.instrument.Counter;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class DasUnknownCallsCollector implements GracefulShutdownStrategy {
+
+  public static final String COUNTER_UNREGISTERED_FETCHED_ROWS = "EntryPoints_Das_Unknown_FetchedRows";
+  public static final String COUNTER_UNREGISTERED_AFFECTED_ROWS = "EntryPoints_Das_Unknown_AffectedRows";
+  public static final String COUNTER_UNREGISTERED_EMPTY_TRANSACTIONS = "EntryPoints_Das_Unknown_EmptyTransactions";
+  public static final String COUNTER_UNREGISTERED_TIME_TAKEN_NS = "EntryPoints_Das_Unknown_TimeTakenNs";
+  public static final String COUNTER_UNREGISTERED_T_QUERIES = "EntryPoints_Das_Unknown_TQueries";
+  public static final String COUNTER_UNREGISTERED_NT_QUERIES = "EntryPoints_Das_Unknown_NTQueries";
+  public static final String COUNTER_UNREGISTERED_ROLLBACKS = "EntryPoints_Das_Unknown_Rollbacks";
+  public static final String COUNTER_UNREGISTERED_COMMITS = "EntryPoints_Das_Unknown_Commits";
+
+  private IMeterCache meterCache;
+  private TaskHandle taskHandle;
+
+  private long iterationsCount;
+
+  public DasUnknownCallsCollector(IExecutorServicesProvider executorServicesProvider, IMeterCache meterCache) {
+    this.meterCache = meterCache;
+
+    taskHandle = executorServicesProvider.getGlobalScheduledTaskExecutor()
+        .scheduleAtFixedInterval(() -> registerUnknownCalls(), Duration.ofSeconds(1), Duration.ofSeconds(1));
+
+    log.info("Starting to collect DAS metrics for unknown calls.");
+  }
+
+  protected void registerUnknownCalls() {
+    for (DatabaseAccessStatistics das : DatabaseAccessStatistics.unknownContextDbDasMap.values()) {
+      final long commits = das.getAndResetCommitsCount();
+      final long rollbacks = das.getAndResetRollbacksCount();
+      final long nonTransactionalQueries = das.getAndResetNonTransactionalQueriesCount();
+      final long transactionalQueries = das.getAndResetTransactionalQueriesCount();
+      final long timeTakenNs = das.getAndResetTimeTakenInDatabaseNs();
+      final long affectedRows = das.getAndResetAffectedRowsCount();
+      final long emptyTransactions = das.getAndResetEmptyTransactionsCount();
+      final long fetchedRows = das.getAndResetFetchedRowsCount();
+
+      TagsSet tagsSet = das.getTagsSet();
+      UnknownCallMeters meters = meterCache.metersContainer(METRIC_PREFIX_DAS + "unknownCallMetrics", tagsSet, () -> {
+        UnknownCallMeters result = new UnknownCallMeters();
+        result.commits = meterCache.counter(COUNTER_UNREGISTERED_COMMITS, tagsSet);
+        result.rollbacks = meterCache.counter(COUNTER_UNREGISTERED_ROLLBACKS, tagsSet);
+        result.nonTransactionalQueries = meterCache.counter(COUNTER_UNREGISTERED_NT_QUERIES, tagsSet);
+        result.transactionalQueries = meterCache.counter(COUNTER_UNREGISTERED_T_QUERIES, tagsSet);
+        result.timeTakenNs = meterCache.counter(COUNTER_UNREGISTERED_TIME_TAKEN_NS, tagsSet);
+        result.emptyTransactions = meterCache.counter(COUNTER_UNREGISTERED_EMPTY_TRANSACTIONS, tagsSet);
+        result.affectedRows = meterCache.counter(COUNTER_UNREGISTERED_AFFECTED_ROWS, tagsSet);
+        result.fetchedRows = meterCache.counter(COUNTER_UNREGISTERED_FETCHED_ROWS, tagsSet);
+        return result;
+      });
+
+      meters.commits.increment(commits);
+      meters.rollbacks.increment(rollbacks);
+      meters.nonTransactionalQueries.increment(nonTransactionalQueries);
+      meters.transactionalQueries.increment(transactionalQueries);
+      meters.timeTakenNs.increment(timeTakenNs);
+      meters.emptyTransactions.increment(emptyTransactions);
+      meters.affectedRows.increment(affectedRows);
+      meters.fetchedRows.increment(fetchedRows);
+    }
+
+    iterationsCount++;
+  }
+
+  protected long getIterationsCount() {
+    return iterationsCount;
+  }
+
+  private static class UnknownCallMeters {
+
+    private Counter commits;
+    private Counter rollbacks;
+    private Counter nonTransactionalQueries;
+    private Counter transactionalQueries;
+    private Counter timeTakenNs;
+    private Counter emptyTransactions;
+    private Counter affectedRows;
+    private Counter fetchedRows;
+  }
+
+  @Override
+  public boolean canShutdown() {
+    return true;
+  }
+
+  @Override
+  public void applicationTerminating() {
+    taskHandle.stop();
+  }
+}

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/databaseaccessstatistics/DasUnknownCallsCollector.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/databaseaccessstatistics/DasUnknownCallsCollector.java
@@ -98,6 +98,7 @@ public class DasUnknownCallsCollector implements GracefulShutdownStrategy {
 
   @Override
   public void applicationTerminating() {
+    log.info("Stopping collecting of DAS metrics for unknown calls.");
     taskHandle.stop();
   }
 }

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/TableAccessStatisticsSpyqlListener.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/TableAccessStatisticsSpyqlListener.java
@@ -44,6 +44,7 @@ public class TableAccessStatisticsSpyqlListener implements SpyqlDataSourceListen
   public static final String GAUGE_SQL_PARSER_RESULT_CACHE_HIT_RATIO = "EntryPoints_Tas_SqlParseResultsCache_hitRatio";
   public static final String GAUGE_SQL_PARSER_RESULT_CACHE_SIZE = "EntryPoints_Tas_SqlParseResultsCache_size";
 
+  public static final String COUNTER_PARSES = "EntryPoints_Tas_Parses";
   public static final String COUNTER_FAILED_PARSES = "EntryPoints_Tas_FailedParses";
   public static final String COUNTER_UNCOUNTED_QUERIES = "EntryPoints_Tas_UncountedQueries";
   public static final String TIMER_FIRST_TABLE_ACCESS = "EntryPoints_Tas_FirstTableAccess";
@@ -107,6 +108,12 @@ public class TableAccessStatisticsSpyqlListener implements SpyqlDataSourceListen
           sqlOp.getTableNames().add(tableName.intern());
         }
       }
+      meterCache.counter(COUNTER_PARSES, TagsSet.of(
+          EntryPointsMetrics.TAG_DATABASE, databaseName,
+          TwContextMetricsTemplate.TAG_EP_GROUP, context.getGroup(),
+          TwContextMetricsTemplate.TAG_EP_NAME, context.getName(),
+          TwContextMetricsTemplate.TAG_EP_OWNER, context.getOwner()
+      )).increment();
     } catch (Throwable t) {
       meterCache.counter(COUNTER_FAILED_PARSES, TagsSet.of(
           EntryPointsMetrics.TAG_DATABASE, databaseName,


### PR DESCRIPTION
## Context

### Added

* Counter `EntryPoints_Tas_Parses`, to count per entrypoint, how many parses have been done.
  It allows to identify, which service components are generating most distinct queries and thus bloating the cache or just burning CPU for parses.

### Changed

* DAS for database access done outside of entrypoints are now collected in a separate thread.
  This would allow to collect those metrics even when the service does not have any entrypoints or they are
  infrequently accessed.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
