### PR TITLE
Fix slow parsing logging

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ testImplementation "com.transferwise.common:tw-entrypoints"
 
 ## Table access statistics and `JSqlParser` library
 
-We are using (JSqlParser)[https://github.com/JSQLParser/JSqlParser] library to parse table names from queries.
+We are using [JSqlParser](https://github.com/JSQLParser/JSqlParser) library to parse table names from queries.
 
 The library is pretty good, but some services have few queries, it can not parse. Also, sometimes the parsing can take so long,
 that it will create latency spikes or cpu burns.

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/DefaultTasQueryParsingListener.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/DefaultTasQueryParsingListener.java
@@ -11,7 +11,7 @@ public class DefaultTasQueryParsingListener implements TasQueryParsingListener {
       + "or provide `DefaultTasQueryParsingInterceptor` implementation to provide the "
       + "query parse result manually.";
   public static final String FAILED_PARSING_LOG_MESSAGE = "Parsing statement '{}' failed." + FAILED_PARSING_SUGGESTION;
-  public static final String SLOW_PARSING_LOG_MESSAGE = "Statement '{}' parsing took {} ms." + FAILED_PARSING_LOG_MESSAGE;
+  public static final String SLOW_PARSING_LOG_MESSAGE = "Statement '{}' parsing took {} ms." + FAILED_PARSING_SUGGESTION;
 
 
   private EntryPointsProperties entryPointsProperties;


### PR DESCRIPTION
## Context

Slow parsing log message is broken (parameter is missing). Is this seventy characters already?

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
