### PR TITLE
Allowing to disable query parsing, for example during Flyway migration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.0] - 2023-06-05
+
+### Changed
+
+* Handling more sql-s the JSqlParser can not parse.
+
+### Added
+
+* A mechanism to disable query parsing through `TwContext` - `TasUtils`.
+
+* Flyway integration for TAS.
+  As JSqlParser is not able to parse DDL queries, we will disable the query parsing for Flyway.
+
 ## [2.11.0] - 2023-05-18
 
 ### Changed

--- a/docs/index.md
+++ b/docs/index.md
@@ -127,6 +127,40 @@ public class MyTasQueryParsingListener extends DefaultTasQueryParsingListener {
 }
 ```
 
+The library is automatically disabling query parsing during Flyway migration, but only when you use Spring Boot autoconfiguration to setup Flyway.
+
+If you create the Flyway bean manually, then run the `FluentConfiguration` through flyway customizers.
+
+For example.
+
+<!-- @formatter:off -->
+```java
+@Bean
+Flyway flyway(@Qualifier("dataSource") DataSource dataSource, List<FlywayConfigurationCustomizer> flywayConfigurationCustomizers) {
+    FluentConfiguration config = Flyway.configure()... ;
+
+    for (var flywayConfigurationCustomizer : flywayConfigurationCustomizers){
+        flywayConfigurationCustomizer.customize(config);
+    }
+
+    return new Flyway(config);
+}
+```
+<!-- @formatter:on -->
+
+When you would need to disable the query parsing for specific queries, or routine, surround those with `TwContext` and use `TasUtils`.
+
+E.g.
+
+<!-- @formatter:off -->
+```java
+TwContext.current().createSubContext().execute(() -> {
+  TasUtils.disableQueryParsing(TwContext.current());
+  jdbcTemplate.update("alter update create blah");
+});
+```
+<!-- @formatter:on -->
+
 ## License
 
 Copyright 2021 TransferWise Ltd.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.11.0
+version=2.12.0

--- a/tw-entrypoints-starter/build.gradle
+++ b/tw-entrypoints-starter/build.gradle
@@ -8,6 +8,7 @@ apply from: "${project.rootDir}/build.publishing.gradle"
 dependencies {
     annotationProcessor libraries.springBootConfigurationProcessor
     compileOnly libraries.springBootConfigurationProcessor
+    compileOnly libraries.flywayCore
 
     implementation(project(":tw-entrypoints"))
 

--- a/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/EntryPointsAutoConfiguration.java
+++ b/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/EntryPointsAutoConfiguration.java
@@ -13,12 +13,14 @@ import com.transferwise.common.entrypoints.tableaccessstatistics.DefaultTasParse
 import com.transferwise.common.entrypoints.tableaccessstatistics.DefaultTasQueryParsingInterceptor;
 import com.transferwise.common.entrypoints.tableaccessstatistics.DefaultTasQueryParsingListener;
 import com.transferwise.common.entrypoints.tableaccessstatistics.TableAccessStatisticsBeanPostProcessor;
+import com.transferwise.common.entrypoints.tableaccessstatistics.TasFlywayConfigurationCustomizer;
 import com.transferwise.common.entrypoints.tableaccessstatistics.TasParsedQueryRegistry;
 import com.transferwise.common.entrypoints.tableaccessstatistics.TasQueryParsingInterceptor;
 import com.transferwise.common.entrypoints.tableaccessstatistics.TasQueryParsingListener;
 import com.transferwise.common.entrypoints.transactionstatistics.TransactionStatisticsBeanPostProcessor;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -76,6 +78,20 @@ public class EntryPointsAutoConfiguration {
   @ConditionalOnMissingBean(TasQueryParsingListener.class)
   public DefaultTasQueryParsingListener twEntryPointsTableAccessStatisticsQueryParsingListener(EntryPointsProperties entryPointsProperties) {
     return new DefaultTasQueryParsingListener(entryPointsProperties);
+  }
+
+  @Configuration
+  @ConditionalOnProperty(name = "tw-entrypoints.tas.enabled", havingValue = "true", matchIfMissing = true)
+  @ConditionalOnClass(name = {"org.flywaydb.core.api.configuration.FluentConfiguration",
+      "org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer"})
+  protected static class FlywayInterceptionConfiguration {
+
+    @Bean
+    @ConditionalOnProperty(name = "tw-entrypoints.tas.flyway-integration.enabled", havingValue = "true", matchIfMissing = true)
+    public TasFlywayConfigurationCustomizer tasFlywayConfigurationCustomizer() {
+      return new TasFlywayConfigurationCustomizer();
+    }
+
   }
 
   @Bean

--- a/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/TasFlywayConfigurationCustomizer.java
+++ b/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/TasFlywayConfigurationCustomizer.java
@@ -1,0 +1,60 @@
+package com.transferwise.common.entrypoints.tableaccessstatistics;
+
+import com.transferwise.common.context.TwContext;
+import lombok.extern.slf4j.Slf4j;
+import org.flywaydb.core.api.callback.Callback;
+import org.flywaydb.core.api.callback.Context;
+import org.flywaydb.core.api.callback.Event;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
+import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
+
+/**
+ * Turns off query parsing during Flyway migration.
+ *
+ * <p>JSQLParser library we use, is not able to parse DDL queries.
+ */
+@Slf4j
+public class TasFlywayConfigurationCustomizer implements FlywayConfigurationCustomizer {
+
+  boolean queryParsingWasDisabled;
+  boolean queryParsingWasEnabled;
+
+  @Override
+  public void customize(FluentConfiguration configuration) {
+    configuration.callbacks(new Callback() {
+      @Override
+      public boolean supports(Event event, Context context) {
+        return true;
+      }
+
+      @Override
+      public boolean canHandleInTransaction(Event event, Context context) {
+        return true;
+      }
+
+      @Override
+      public void handle(Event event, Context context) {
+        if (event == Event.BEFORE_MIGRATE) {
+          log.info("Disabling TAS query parsing before Flyway migration.");
+
+          var twContext = TwContext.current().createSubContext().asEntryPoint("Flyway", "Flyway");
+          twContext.attach();
+
+          TasUtils.disableQueryParsing(twContext);
+
+          queryParsingWasDisabled = true;
+        } else if (event == Event.AFTER_MIGRATE) {
+          log.debug("Enabling TAS query parsing after Flyway migration.");
+          TwContext.current().detach(TwContext.current().getParent());
+
+          queryParsingWasEnabled = true;
+        }
+      }
+
+      @Override
+      public String getCallbackName() {
+        return "tw-entrypoints-tas";
+      }
+    });
+  }
+}

--- a/tw-entrypoints-starter/src/test/java/com/transferwise/common/entrypoints/tableaccessstatistics/TestTasQueryParsingInterceptor.java
+++ b/tw-entrypoints-starter/src/test/java/com/transferwise/common/entrypoints/tableaccessstatistics/TestTasQueryParsingInterceptor.java
@@ -16,6 +16,7 @@ public class TestTasQueryParsingInterceptor extends DefaultTasQueryParsingInterc
     if (parsedQuery != null) {
       return InterceptResult.returnParsedQuery(parsedQuery);
     }
+
     return super.intercept(sql);
   }
 }

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/EntryPointsProperties.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/EntryPointsProperties.java
@@ -28,6 +28,7 @@ public class EntryPointsProperties {
 
     private boolean enabled = true;
     private SqlParser sqlParser = new SqlParser();
+    private FlywayIntegration flywayIntegration = new FlywayIntegration();
 
     @Data
     public static class SqlParser {
@@ -39,6 +40,12 @@ public class EntryPointsProperties {
        */
       private Duration parseDurationWarnThreshold = Duration.ofSeconds(1);
       private boolean warnAboutFailedParses = true;
+    }
+
+    @Data
+    public static class FlywayIntegration {
+
+      private boolean enabled = true;
     }
   }
 

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/DefaultTasQueryParsingInterceptor.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/DefaultTasQueryParsingInterceptor.java
@@ -1,15 +1,20 @@
 package com.transferwise.common.entrypoints.tableaccessstatistics;
 
+import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 
 public class DefaultTasQueryParsingInterceptor implements TasQueryParsingInterceptor {
 
+  private static Pattern PG_SET_PATTERN = Pattern.compile("(?is)SET\\s+[a-z_]*\\s+TO\\s+.*");
+
   @Override
   public InterceptResult intercept(String sql) {
-    if (StringUtils.startsWithIgnoreCase(sql, "SET statement_timeout TO")) {
+    sql = StringUtils.trim(sql);
+    if (PG_SET_PATTERN.matcher(sql).matches()) {
       return InterceptResult.doSkip();
     }
 
     return InterceptResult.doContinue();
   }
+
 }

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/TasUtils.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/TasUtils.java
@@ -1,0 +1,23 @@
+package com.transferwise.common.entrypoints.tableaccessstatistics;
+
+import com.transferwise.common.context.TwContext;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class TasUtils {
+
+  public static final String TAS_QUERY_PARSING_DISABLED = "TW_TAS_QUERY_PARSING_DISABLED";
+
+  public void disableQueryParsing(TwContext context) {
+    context.put(TAS_QUERY_PARSING_DISABLED, Boolean.TRUE);
+  }
+
+  public void enableQueryParsing(TwContext context) {
+    context.put(TAS_QUERY_PARSING_DISABLED, null);
+  }
+
+  public boolean isQueryParsingEnabled(TwContext context) {
+    Boolean contextValue = context.get(TAS_QUERY_PARSING_DISABLED);
+    return !Boolean.TRUE.equals(contextValue);
+  }
+}


### PR DESCRIPTION
## Context

### Changed

* Handling more sql-s the JSqlParser can not parse.

### Added

* A mechanism to disable query parsing through `TwContext` - `TasUtils`.

* Flyway integration for TAS.
  As JSqlParser is not able to parse DDL queries, we will disable the query parsing for Flyway.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
