### PR TITLE
Removing quotes around parsed table names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.1] - 2023-06-21
+
+### Changed
+
+* Removing quotes around table names provided by JSqlParser.
+  When table name is quoted in sql, it will be returned by JSqlParser also as quoted. But this will create double metrics from
+  sql not having quotes around table names.
+
 ## [2.12.0] - 2023-06-05
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.12.0
+version=2.12.1

--- a/tw-entrypoints-starter/src/test/java/com/transferwise/common/entrypoints/tableaccessstatistics/TableAccessStatisticsIntTest.java
+++ b/tw-entrypoints-starter/src/test/java/com/transferwise/common/entrypoints/tableaccessstatistics/TableAccessStatisticsIntTest.java
@@ -18,6 +18,8 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -161,9 +163,11 @@ class TableAccessStatisticsIntTest extends BaseIntTest {
     assertThat(((Counter) meters.get(0)).count()).isEqualTo(1);
   }
 
-  @Test
-  public void updateSqlDoneOutsideOfEntrypointGetsAlsoRegistered() {
-    jdbcTemplate.update("update table_a set version=2");
+  // Also tests if quotes are removed before we register metrics.
+  @ParameterizedTest
+  @ValueSource(strings = {"table_a", "`table_a`"})
+  void updateSqlDoneOutsideOfEntrypointGetsAlsoRegistered(String tableName) {
+    jdbcTemplate.update("update " + tableName + " set version=2");
 
     List<Meter> meters = getTableAccessMeters();
 

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/TableAccessStatisticsSpyqlListener.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/TableAccessStatisticsSpyqlListener.java
@@ -144,8 +144,10 @@ public class TableAccessStatisticsSpyqlListener implements SpyqlDataSourceListen
 
         if (tableNames != null) {
           for (String tableName : tableNames) {
+            tableName = trimTableName(tableName);
             // Intern() makes later equal checks much faster.
-            sqlOp.getTableNames().add(tableName.intern());
+            tableName = tableName.intern();
+            sqlOp.getTableNames().add(tableName);
           }
         }
       }
@@ -179,6 +181,21 @@ public class TableAccessStatisticsSpyqlListener implements SpyqlDataSourceListen
     }
 
     return result;
+  }
+
+  protected String trimTableName(String tableName) {
+    if (StringUtils.isEmpty(tableName)) {
+      return tableName;
+    }
+
+    if ((tableName.charAt(0) == '`' && tableName.charAt(tableName.length() - 1) == '`')
+        || (tableName.charAt(0) == '\'' && tableName.charAt(tableName.length() - 1) == '\'')
+        || (tableName.charAt(0) == '"' && tableName.charAt(tableName.length() - 1) == '"')
+    ) {
+      return tableName.substring(1, tableName.length() - 1);
+    }
+
+    return tableName;
   }
 
   protected String getOperationName(Statement stmt) {


### PR DESCRIPTION
## Context

### Changed

* Removing quotes around table names provided by JSqlParser.
  When table name is quoted in sql, it will be returned by JSqlParser also as quoted. But this will create double metrics from
  sql not having quotes around table names.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
