### PR TITLE
Added a metric providing library version in use.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.1] - 2023-07-07
+
+### Added
+
+* `tw.library.info` metric to provide the version.
+
 ## [2.13.0] - 2023-07-04
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.13.0
+version=2.13.1

--- a/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/EntryPointsAutoConfiguration.java
+++ b/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/EntryPointsAutoConfiguration.java
@@ -31,6 +31,14 @@ import org.springframework.context.annotation.Configuration;
 public class EntryPointsAutoConfiguration {
 
   @Bean
+  @ConditionalOnMissingBean(MetricsTemplate.class)
+  public DefaultMetricsTemplate twEntryPointsMetricsTemplate(IMeterCache meterCache) {
+    var template = new DefaultMetricsTemplate(meterCache);
+    template.registerLibrary();
+    return template;
+  }
+
+  @Bean
   @ConfigurationProperties(value = "tw-entrypoints", ignoreUnknownFields = false)
   public EntryPointsProperties twEntryPointsProperties() {
     return new EntryPointsProperties();

--- a/tw-entrypoints-starter/src/test/java/com/transferwise/common/entrypoints/LibraryMetricsIntTest.java
+++ b/tw-entrypoints-starter/src/test/java/com/transferwise/common/entrypoints/LibraryMetricsIntTest.java
@@ -1,0 +1,17 @@
+package com.transferwise.common.entrypoints;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.transferwise.common.entrypoints.test.BaseIntTest;
+import org.junit.jupiter.api.Test;
+
+class LibraryMetricsIntTest extends BaseIntTest {
+
+  @Test
+  void libraryVersionIsProvided() {
+    var gauge = meterRegistry.find("tw.library.info").tags("library", "tw-entrypoints").gauge();
+    assertEquals(1, gauge.value());
+    assertNotNull(gauge.getId().getTag("version"));
+  }
+}

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/DefaultMetricsTemplate.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/DefaultMetricsTemplate.java
@@ -1,0 +1,26 @@
+package com.transferwise.common.entrypoints;
+
+import com.transferwise.common.baseutils.meters.cache.IMeterCache;
+import io.micrometer.core.instrument.Gauge;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class DefaultMetricsTemplate implements MetricsTemplate {
+
+  public static final String GAUGE_LIBRARY_INFO = "tw.library.info";
+
+  private final IMeterCache meterCache;
+
+  @Override
+  public void registerLibrary() {
+    String version = this.getClass().getPackage().getImplementationVersion();
+    if (version == null) {
+      version = "Unknown";
+    }
+
+    Gauge.builder(GAUGE_LIBRARY_INFO, () -> 1d).tags("version", version, "library", "tw-entrypoints")
+        .description("Provides metadata about the library, for example the version.")
+        .register(meterCache.getMeterRegistry());
+
+  }
+}

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/MetricsTemplate.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/MetricsTemplate.java
@@ -1,0 +1,7 @@
+package com.transferwise.common.entrypoints;
+
+public interface MetricsTemplate {
+
+  void registerLibrary();
+
+}

--- a/tw-entrypoints/src/test/java/com/transferwise/common/entrypoints/tableaccessstatistics/SqlParserUtilsTest.java
+++ b/tw-entrypoints/src/test/java/com/transferwise/common/entrypoints/tableaccessstatistics/SqlParserUtilsTest.java
@@ -31,6 +31,9 @@ class SqlParserUtilsTest {
 
     sqls.add("insert into fin_unique_tw_task_key(task_id,key_hash,key) values(?, ?, ?) on conflict (key_hash, key) do nothing");
 
+    // Not supported by JSqlParser
+    // sqls.add("truncate table_a, table_b");
+
     var sqlParser = new SqlParser(Executors.newCachedThreadPool());
     var interceptor = new DefaultTasQueryParsingInterceptor();
 


### PR DESCRIPTION
## Context

It would be good to know which version of the library is used in each service.

Added a metric providing library version in use.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
