### PR TITLE
Fixed tw-entrypoints dependencies list in its POM.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.2] - 2023-07-10
+
+### Fixed
+
+* Runtime dependencies are correctly added into POM, for `tw-entrypoints` module.
+
 ## [2.13.1] - 2023-07-07
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.13.1
+version=2.13.2

--- a/tw-entrypoints/build.gradle
+++ b/tw-entrypoints/build.gradle
@@ -102,7 +102,19 @@ publishing {
                     developerConnection = projectScmConnection
                     url = projectScmUrl
                 }
-                withXml {
+                withXml { xml ->
+                    def dependenciesNode = xml.asNode().get('dependencies') ?: xml.asNode().appendNode('dependencies')
+
+                    project.configurations.getByName("shadow").resolvedConfiguration.firstLevelModuleDependencies.forEach {
+                        if (it.configuration != "platform-runtime") {
+                            def dependencyNode = dependenciesNode.appendNode('dependency')
+                            dependencyNode.appendNode('groupId', it.moduleGroup)
+                            dependencyNode.appendNode('artifactId', it.moduleName)
+                            dependencyNode.appendNode('version', it.moduleVersion)
+                            dependencyNode.appendNode('scope', 'runtime')
+                        }
+                    }
+
                     if (!asNode().dependencyManagement.isEmpty()) {
                         throw new IllegalStateException("There should not be any `dependencyManagement` block in POM.")
                     }


### PR DESCRIPTION
## Context

tw-entrypoints module dependencies list in POM was empty due to moving to usage of shadowJar, sourcesJar, javadocJar construct.

### Fixed

* Runtime dependencies are correctly added into POM, for `tw-entrypoints` module.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
