### PR TITLE
Change SqlOperation visibility to public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-* Visibility of `ParsedQuery.SqlOperation` is changed from package protected to public
+* Visibility of `ParsedQuery.SqlOperation` is changed from package protected to public.
+* Visibility of `ParsedQuery.addOperation` is changed from package protected to public.
 
 ## [2.13.2] - 2023-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.3] - 2023-07-19
+
+### Fixed
+
+* Visibility of `ParsedQuery.SqlOperation` is changed from package protected to public
+
 ## [2.13.2] - 2023-07-10
 
 ### Fixed

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,7 +81,7 @@ public class MyTasQueryParsingInterceptor extends DefaultTasQueryParsingIntercep
 
     else if (sql.equals(knownUnParseableSql)){
       return InterceptResult.returnParsedQuery(new ParsedQuery()
-          .addOperation("insert",new SqlOperation()
+          .addOperation("insert", new ParsedQuery.SqlOperation()
               // Main table should always be first, as we register "first-table" metrics by that.
               .addTable("transfer")
               .addTable("payout")));
@@ -102,7 +102,7 @@ private TasParsedQueryRegistry registry;
 
 public void registerBadSqls(){
     registry.register(knownUnParseableSql,new ParsedQuery()
-      .addOperation("insert",new SqlOperation()
+      .addOperation("insert", new ParsedQuery.SqlOperation()
          .addTable("transfer")
          .addTable("payout")));
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,7 @@ Example for `TasQueryParsingInterceptor`.
 
 <!-- @formatter:off -->
 ```java
+@Component
 public class MyTasQueryParsingInterceptor extends DefaultTasQueryParsingInterceptor {
 
   @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.13.2
+version=2.13.3

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/ParsedQuery.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/ParsedQuery.java
@@ -13,7 +13,7 @@ public class ParsedQuery {
 
   private Map<String, SqlOperation> operations = new HashMap<>();
 
-  ParsedQuery addOperation(String operationName, SqlOperation operation) {
+  public ParsedQuery addOperation(String operationName, SqlOperation operation) {
     operations.put(operationName, operation);
     return this;
   }

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/ParsedQuery.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/ParsedQuery.java
@@ -20,7 +20,7 @@ public class ParsedQuery {
 
   @Data
   @Accessors(chain = true)
-  static class SqlOperation {
+  public static class SqlOperation {
 
     private Set<String> tableNames = new HashSet<>();
 


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->
[Documentation for table statistics](https://github.com/transferwise/tw-entrypoints/blob/master/docs/index.md#table-access-statistics-and-jsqlparser-library) mention a code example which uses a non-public class. It is now made public.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
