### PR TITLE
Allowing more Wise teams to create PRs.

### DIFF
--- a/.github/tw-rules.yaml
+++ b/.github/tw-rules.yaml
@@ -1,1 +1,13 @@
 runChecks: true
+
+actions:
+  branch-protection-settings:
+    branches:
+      - name: master
+        checks:
+          - name: Build and Test
+            type: tests
+  sync-codeowners:
+    extraWriters:
+      - product-engineering
+      - platform


### PR DESCRIPTION
## Context

Currently only application-engineering team in Wise can create PRs, but all the engineers should.

Allowing more Wise teams to create PRs.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
