### PR TITLE
[APPENG-927] Yield MetricFilter's as Beans for Spring to apply to MeterRegistry via post processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.16.3] - 2024-08-7
+
+### Changed
+
+* MeterFilter's applied by the library are no longer explicitly applied and are instead
+
 ## [2.16.2] - 2024-07-16
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.16.2
+version=2.16.3

--- a/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/EntryPointsAutoConfiguration.java
+++ b/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/EntryPointsAutoConfiguration.java
@@ -19,6 +19,7 @@ import com.transferwise.common.entrypoints.tableaccessstatistics.TasParsedQueryR
 import com.transferwise.common.entrypoints.tableaccessstatistics.TasQueryParsingInterceptor;
 import com.transferwise.common.entrypoints.tableaccessstatistics.TasQueryParsingListener;
 import com.transferwise.common.entrypoints.transactionstatistics.TransactionStatisticsBeanPostProcessor;
+import com.transferwise.common.entrypoints.transactionstatistics.TsMeterFilter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import org.springframework.beans.factory.BeanFactory;
@@ -121,7 +122,7 @@ public class EntryPointsAutoConfiguration {
   @Bean
   @ConditionalOnProperty(name = "tw-entrypoints.ts.enabled", havingValue = "true", matchIfMissing = true)
   public static MeterFilter twEntryPointsTransactionStatisticsMetricsFilter() {
-    return new TasMeterFilter();
+    return new TsMeterFilter();
   }
 
   @Bean

--- a/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/EntryPointsAutoConfiguration.java
+++ b/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/EntryPointsAutoConfiguration.java
@@ -61,7 +61,7 @@ public class EntryPointsAutoConfiguration {
   @Bean
   @ConditionalOnProperty(name = "tw-entrypoints.das.enabled", havingValue = "true", matchIfMissing = true)
   @ConditionalOnMissingBean
-  public DatabaseAccessStatisticsBeanPostProcessor twEntryPointsDatabaseAccessStatisticsBeanPostProcessor() {
+  public static DatabaseAccessStatisticsBeanPostProcessor twEntryPointsDatabaseAccessStatisticsBeanPostProcessor() {
     return new DatabaseAccessStatisticsBeanPostProcessor();
   }
 
@@ -75,7 +75,7 @@ public class EntryPointsAutoConfiguration {
   @Bean
   @ConditionalOnProperty(name = "tw-entrypoints.tas.enabled", havingValue = "true", matchIfMissing = true)
   @ConditionalOnMissingBean
-  public TableAccessStatisticsBeanPostProcessor twEntryPointsTableAccessStatisticsBeanPostProcessor(BeanFactory beanFactory) {
+  public static TableAccessStatisticsBeanPostProcessor twEntryPointsTableAccessStatisticsBeanPostProcessor(BeanFactory beanFactory) {
     return new TableAccessStatisticsBeanPostProcessor(beanFactory);
   }
 
@@ -124,7 +124,7 @@ public class EntryPointsAutoConfiguration {
   @Bean
   @ConditionalOnProperty(name = "tw-entrypoints.ts.enabled", havingValue = "true", matchIfMissing = true)
   @ConditionalOnMissingBean
-  public TransactionStatisticsBeanPostProcessor twEntryPointsTransactionStatisticsBeanPostProcessor(BeanFactory beanFactory) {
+  public static TransactionStatisticsBeanPostProcessor twEntryPointsTransactionStatisticsBeanPostProcessor(BeanFactory beanFactory) {
     return new TransactionStatisticsBeanPostProcessor(beanFactory);
   }
 

--- a/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/EntryPointsAutoConfiguration.java
+++ b/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/EntryPointsAutoConfiguration.java
@@ -5,9 +5,11 @@ import com.transferwise.common.baseutils.concurrency.IExecutorServicesProvider;
 import com.transferwise.common.baseutils.meters.cache.IMeterCache;
 import com.transferwise.common.baseutils.meters.cache.MeterCache;
 import com.transferwise.common.context.TwContext;
+import com.transferwise.common.entrypoints.databaseaccessstatistics.DasMeterFilter;
 import com.transferwise.common.entrypoints.databaseaccessstatistics.DasUnknownCallsCollector;
 import com.transferwise.common.entrypoints.databaseaccessstatistics.DatabaseAccessStatisticsBeanPostProcessor;
 import com.transferwise.common.entrypoints.databaseaccessstatistics.DatabaseAccessStatisticsEntryPointInterceptor;
+import com.transferwise.common.entrypoints.executionstatistics.EsMeterFilter;
 import com.transferwise.common.entrypoints.executionstatistics.ExecutionStatisticsEntryPointInterceptor;
 import com.transferwise.common.entrypoints.tableaccessstatistics.DefaultTasParsedQueryRegistry;
 import com.transferwise.common.entrypoints.tableaccessstatistics.DefaultTasQueryParsingInterceptor;
@@ -59,20 +61,27 @@ public class EntryPointsAutoConfiguration {
   @Bean
   @ConditionalOnProperty(name = "tw-entrypoints.das.enabled", havingValue = "true", matchIfMissing = true)
   @ConditionalOnMissingBean
-  public static DatabaseAccessStatisticsBeanPostProcessor twEntryPointsDatabaseAccessStatisticsBeanPostProcessor() {
+  public DatabaseAccessStatisticsBeanPostProcessor twEntryPointsDatabaseAccessStatisticsBeanPostProcessor() {
     return new DatabaseAccessStatisticsBeanPostProcessor();
+  }
+
+
+  @Bean
+  @ConditionalOnProperty(name = "tw-entrypoints.das.enabled", havingValue = "true", matchIfMissing = true)
+  public MeterFilter twEntryPointsDatabaseAccessStatisticsMeterFilter() {
+    return new DasMeterFilter();
   }
 
   @Bean
   @ConditionalOnProperty(name = "tw-entrypoints.tas.enabled", havingValue = "true", matchIfMissing = true)
   @ConditionalOnMissingBean
-  public static TableAccessStatisticsBeanPostProcessor twEntryPointsTableAccessStatisticsBeanPostProcessor(BeanFactory beanFactory) {
+  public TableAccessStatisticsBeanPostProcessor twEntryPointsTableAccessStatisticsBeanPostProcessor(BeanFactory beanFactory) {
     return new TableAccessStatisticsBeanPostProcessor(beanFactory);
   }
 
   @Bean
   @ConditionalOnProperty(name = "tw-entrypoints.tas.enabled", havingValue = "true", matchIfMissing = true)
-  public static MeterFilter twEntryPointsTableAccessStatisticsMeterFilter() {
+  public MeterFilter twEntryPointsTableAccessStatisticsMeterFilter() {
     return new TasMeterFilter();
   }
 
@@ -115,13 +124,13 @@ public class EntryPointsAutoConfiguration {
   @Bean
   @ConditionalOnProperty(name = "tw-entrypoints.ts.enabled", havingValue = "true", matchIfMissing = true)
   @ConditionalOnMissingBean
-  public static TransactionStatisticsBeanPostProcessor twEntryPointsTransactionStatisticsBeanPostProcessor(BeanFactory beanFactory) {
+  public TransactionStatisticsBeanPostProcessor twEntryPointsTransactionStatisticsBeanPostProcessor(BeanFactory beanFactory) {
     return new TransactionStatisticsBeanPostProcessor(beanFactory);
   }
 
   @Bean
   @ConditionalOnProperty(name = "tw-entrypoints.ts.enabled", havingValue = "true", matchIfMissing = true)
-  public static MeterFilter twEntryPointsTransactionStatisticsMetricsFilter() {
+  public MeterFilter twEntryPointsTransactionStatisticsMetricsFilter() {
     return new TsMeterFilter();
   }
 
@@ -133,6 +142,13 @@ public class EntryPointsAutoConfiguration {
     TwContext.addExecutionInterceptor(interceptor);
     return interceptor;
   }
+
+  @Bean
+  @ConditionalOnProperty(name = "tw-entrypoints.es.enabled", havingValue = "true", matchIfMissing = true)
+  public MeterFilter twEntryPointsExecutionStatisticsMetricsFilter() {
+    return new EsMeterFilter();
+  }
+
 
   @Bean
   @ConditionalOnMissingBean(IExecutorServicesProvider.class)

--- a/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/EntryPointsAutoConfiguration.java
+++ b/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/EntryPointsAutoConfiguration.java
@@ -19,8 +19,8 @@ import com.transferwise.common.entrypoints.tableaccessstatistics.TasParsedQueryR
 import com.transferwise.common.entrypoints.tableaccessstatistics.TasQueryParsingInterceptor;
 import com.transferwise.common.entrypoints.tableaccessstatistics.TasQueryParsingListener;
 import com.transferwise.common.entrypoints.transactionstatistics.TransactionStatisticsBeanPostProcessor;
-import com.transferwise.common.entrypoints.transactionstatistics.TsMeterFilter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -65,10 +65,14 @@ public class EntryPointsAutoConfiguration {
   @Bean
   @ConditionalOnProperty(name = "tw-entrypoints.tas.enabled", havingValue = "true", matchIfMissing = true)
   @ConditionalOnMissingBean
-  public static TableAccessStatisticsBeanPostProcessor twEntryPointsTableAccessStatisticsBeanPostProcessor(BeanFactory beanFactory,
-      MeterRegistry meterRegistry) {
-    meterRegistry.config().meterFilter(new TasMeterFilter());
+  public static TableAccessStatisticsBeanPostProcessor twEntryPointsTableAccessStatisticsBeanPostProcessor(BeanFactory beanFactory) {
     return new TableAccessStatisticsBeanPostProcessor(beanFactory);
+  }
+
+  @Bean
+  @ConditionalOnProperty(name = "tw-entrypoints.tas.enabled", havingValue = "true", matchIfMissing = true)
+  public static MeterFilter twEntryPointsTableAccessStatisticsMeterFilter() {
+    return new TasMeterFilter();
   }
 
   @Bean
@@ -77,6 +81,7 @@ public class EntryPointsAutoConfiguration {
   public DefaultTasParsedQueryRegistry twEntryPointsTableAccessStatisticsParsedQueryRegistry() {
     return new DefaultTasParsedQueryRegistry();
   }
+
 
   @Bean
   @ConditionalOnProperty(name = "tw-entrypoints.tas.enabled", havingValue = "true", matchIfMissing = true)
@@ -109,10 +114,14 @@ public class EntryPointsAutoConfiguration {
   @Bean
   @ConditionalOnProperty(name = "tw-entrypoints.ts.enabled", havingValue = "true", matchIfMissing = true)
   @ConditionalOnMissingBean
-  public static TransactionStatisticsBeanPostProcessor twEntryPointsTransactionStatisticsBeanPostProcessor(BeanFactory beanFactory,
-      MeterRegistry meterRegistry) {
-    meterRegistry.config().meterFilter(new TsMeterFilter());
+  public static TransactionStatisticsBeanPostProcessor twEntryPointsTransactionStatisticsBeanPostProcessor(BeanFactory beanFactory) {
     return new TransactionStatisticsBeanPostProcessor(beanFactory);
+  }
+
+  @Bean
+  @ConditionalOnProperty(name = "tw-entrypoints.ts.enabled", havingValue = "true", matchIfMissing = true)
+  public static MeterFilter twEntryPointsTransactionStatisticsMetricsFilter() {
+    return new TasMeterFilter();
   }
 
   @Bean

--- a/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/EntryPointsAutoConfiguration.java
+++ b/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/EntryPointsAutoConfiguration.java
@@ -14,10 +14,12 @@ import com.transferwise.common.entrypoints.tableaccessstatistics.DefaultTasQuery
 import com.transferwise.common.entrypoints.tableaccessstatistics.DefaultTasQueryParsingListener;
 import com.transferwise.common.entrypoints.tableaccessstatistics.TableAccessStatisticsBeanPostProcessor;
 import com.transferwise.common.entrypoints.tableaccessstatistics.TasFlywayConfigurationCustomizer;
+import com.transferwise.common.entrypoints.tableaccessstatistics.TasMeterFilter;
 import com.transferwise.common.entrypoints.tableaccessstatistics.TasParsedQueryRegistry;
 import com.transferwise.common.entrypoints.tableaccessstatistics.TasQueryParsingInterceptor;
 import com.transferwise.common.entrypoints.tableaccessstatistics.TasQueryParsingListener;
 import com.transferwise.common.entrypoints.transactionstatistics.TransactionStatisticsBeanPostProcessor;
+import com.transferwise.common.entrypoints.transactionstatistics.TsMeterFilter;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -63,7 +65,9 @@ public class EntryPointsAutoConfiguration {
   @Bean
   @ConditionalOnProperty(name = "tw-entrypoints.tas.enabled", havingValue = "true", matchIfMissing = true)
   @ConditionalOnMissingBean
-  public static TableAccessStatisticsBeanPostProcessor twEntryPointsTableAccessStatisticsBeanPostProcessor(BeanFactory beanFactory) {
+  public static TableAccessStatisticsBeanPostProcessor twEntryPointsTableAccessStatisticsBeanPostProcessor(BeanFactory beanFactory,
+      MeterRegistry meterRegistry) {
+    meterRegistry.config().meterFilter(new TasMeterFilter());
     return new TableAccessStatisticsBeanPostProcessor(beanFactory);
   }
 
@@ -105,7 +109,9 @@ public class EntryPointsAutoConfiguration {
   @Bean
   @ConditionalOnProperty(name = "tw-entrypoints.ts.enabled", havingValue = "true", matchIfMissing = true)
   @ConditionalOnMissingBean
-  public static TransactionStatisticsBeanPostProcessor twEntryPointsTransactionStatisticsBeanPostProcessor(BeanFactory beanFactory) {
+  public static TransactionStatisticsBeanPostProcessor twEntryPointsTransactionStatisticsBeanPostProcessor(BeanFactory beanFactory,
+      MeterRegistry meterRegistry) {
+    meterRegistry.config().meterFilter(new TsMeterFilter());
     return new TransactionStatisticsBeanPostProcessor(beanFactory);
   }
 

--- a/tw-entrypoints-starter/src/test/java/com/transferwise/common/entrypoints/transactionstatistics/TransactionStatisticsIntTest.java
+++ b/tw-entrypoints-starter/src/test/java/com/transferwise/common/entrypoints/transactionstatistics/TransactionStatisticsIntTest.java
@@ -32,7 +32,7 @@ public class TransactionStatisticsIntTest extends BaseIntTest {
   }
 
   @Test
-  public void successfullTransactionGetsRegisterd() {
+  public void successfulTransactionGetsRegistered() {
     transactionsHelper.withTransaction().call(() -> {
       jdbcTemplate.update("update table_a set version=2");
       return null;
@@ -73,7 +73,7 @@ public class TransactionStatisticsIntTest extends BaseIntTest {
   }
 
   @Test
-  public void rollbackGetsRegisterd() {
+  public void rollbackGetsRegistered() {
     try {
       transactionsHelper.withTransaction().call(() -> {
         jdbcTemplate.update("update table_a set version=2");

--- a/tw-entrypoints-starter/src/test/resources/application.yml
+++ b/tw-entrypoints-starter/src/test/resources/application.yml
@@ -13,9 +13,11 @@ tw-graceful-shutdown:
 
 ---
 spring:
+  datasource:
+    embedded:
+      mysql:
+        port: 3306
+        enable: true
   config:
     activate:
       on-profile: continuous-integration
-embedded:
-  mysql:
-    port: 3306

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/databaseaccessstatistics/DatabaseAccessStatisticsEntryPointInterceptor.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/databaseaccessstatistics/DatabaseAccessStatisticsEntryPointInterceptor.java
@@ -35,7 +35,6 @@ public class DatabaseAccessStatisticsEntryPointInterceptor implements TwContextE
 
   public DatabaseAccessStatisticsEntryPointInterceptor(IMeterCache meterCache) {
     this.meterCache = meterCache;
-    meterCache.getMeterRegistry().config().meterFilter(new DasMeterFilter());
   }
 
   @Override

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/executionstatistics/ExecutionStatisticsEntryPointInterceptor.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/executionstatistics/ExecutionStatisticsEntryPointInterceptor.java
@@ -18,7 +18,6 @@ public class ExecutionStatisticsEntryPointInterceptor implements TwContextExecut
 
   public ExecutionStatisticsEntryPointInterceptor(IMeterCache meterCache) {
     this.meterCache = meterCache;
-    meterCache.getMeterRegistry().config().meterFilter(new EsMeterFilter());
   }
 
   @Override

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/TableAccessStatisticsSpyqlListener.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/TableAccessStatisticsSpyqlListener.java
@@ -95,7 +95,6 @@ public class TableAccessStatisticsSpyqlListener implements SpyqlDataSourceListen
     this.tasQueryParsingListener = tasQueryParsingListener;
 
     final MeterRegistry meterRegistry = meterCache.getMeterRegistry();
-    meterRegistry.config().meterFilter(new TasMeterFilter());
 
     sqlParseResultsCache = Caffeine.newBuilder().maximumWeight(entryPointsProperties.getTas().getSqlParser().getCacheSizeMib() * MIB).recordStats()
         .executor(executorService)

--- a/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/transactionstatistics/TransactionsStatisticsSpyqlListener.java
+++ b/tw-entrypoints/src/main/java/com/transferwise/common/entrypoints/transactionstatistics/TransactionsStatisticsSpyqlListener.java
@@ -67,7 +67,6 @@ public class TransactionsStatisticsSpyqlListener implements SpyqlDataSourceListe
   public TransactionsStatisticsSpyqlListener(IMeterCache meterCache, String databaseName) {
     this.dbTag = Tag.of(EntryPointsMetrics.TAG_DATABASE, databaseName);
     this.meterCache = meterCache;
-    meterCache.getMeterRegistry().config().meterFilter(new TsMeterFilter());
   }
 
   @Override


### PR DESCRIPTION
## Context

A PR to micrometer (https://github.com/micrometer-metrics/micrometer/pull/4917) added a log message to warn that `MeterFilter`'s have been applied to `MeterRegistry` after meters have been registered with it. 

This library is an offender. This PR no longer explicitly applied `MeterFilter`'s itself and insteads yields them as Beans for Spring to pass to `MeterRegistryPostProcessor` which will apply them.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 


## Details from ticket: [APPENG-927](https://transferwise.atlassian.net/browse/APPENG-927)

### Stop explicitly applying MeterFilter's in all platform libraries

>Context in Slack thread: [https://wise.slack.com/archives/C0437QJBY4V/p1722955739049859|https://wise.slack.com/archives/C0437QJBY4V/p1722955739049859|smart-link] 
>
>We should go over our platform libraries and ensure that we don’t explicitly apply MeterFilter’s to MeterRegistry. Instead we should created the MeterFilter’s and expose them to Spring as Bean’s so that {{MeterRegistryPostProcessor}} can apply them correctly for us.
>
>Known offenders are:
>
>* tw-entrypoints
>* tw-service-comms
>* tw-tkms
>* wise-kafka-processor


[APPENG-927]: https://transferwise.atlassian.net/browse/APPENG-927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ