### PR TITLE
APPENG-985: Point documentation to our new support channel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Apache 2](https://img.shields.io/hexpm/l/plug.svg)
 ![Java 11](https://img.shields.io/badge/Java-11-blue.svg)
 ![Maven Central](https://badgen.net/maven/v/maven-central/com.transferwise.common/tw-entrypoints)
-[![Owners](https://img.shields.io/badge/team-AppEng-blueviolet.svg?logo=wise)](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/2520812116/Application+Engineering+Team) [![Slack](https://img.shields.io/badge/slack-sre--guild-blue.svg?logo=slack)](https://app.slack.com/client/T026FB76G/CLR1U8SNS)
+[![Owners](https://img.shields.io/badge/team-AppEng-blueviolet.svg?logo=wise)](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/2520812116/Application+Engineering+Team) [![Slack](https://img.shields.io/badge/slack-appeng--pub-blue.svg?logo=slack)](https://wise.enterprise.slack.com/archives/C07QSPFLM5X)
 > Use the `@application-engineering-on-call` handle on Slack for help.
 ---
 


### PR DESCRIPTION
## Context
APPENG-985: Point documentation to our new support channel.
Following movement of support from #sre-guild to #appeng-pub we are renaming all occurrences and fixing slack links.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
