### PR TITLE
Flway Cutomizer createSchema Warning (PAYINP-3244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.16.6] - 2025-06-02
+
+### Changed
+
+* Change the flyway configuration customizer to avoid signalling it supports events that it takes no action for. This avoids triggering a warning
+  for services using Spring Boot 3.4 about the createSchema callback being deprecated.
+
+
 ## [2.16.5] - 2025-05-08
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.16.5
+version=2.16.6

--- a/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/TasFlywayConfigurationCustomizer.java
+++ b/tw-entrypoints-starter/src/main/java/com/transferwise/common/entrypoints/tableaccessstatistics/TasFlywayConfigurationCustomizer.java
@@ -1,6 +1,8 @@
 package com.transferwise.common.entrypoints.tableaccessstatistics;
 
 import com.transferwise.common.context.TwContext;
+import java.util.EnumSet;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.flywaydb.core.api.callback.Callback;
 import org.flywaydb.core.api.callback.Context;
@@ -16,6 +18,8 @@ import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomiz
 @Slf4j
 public class TasFlywayConfigurationCustomizer implements FlywayConfigurationCustomizer {
 
+  private static final Set<Event> HANDLED_EVENTS = EnumSet.of(Event.BEFORE_VALIDATE, Event.AFTER_MIGRATE);
+
   boolean queryParsingWasDisabled;
   boolean queryParsingWasEnabled;
 
@@ -24,7 +28,7 @@ public class TasFlywayConfigurationCustomizer implements FlywayConfigurationCust
     configuration.callbacks(new Callback() {
       @Override
       public boolean supports(Event event, Context context) {
-        return true;
+        return HANDLED_EVENTS.contains(event);
       }
 
       @Override


### PR DESCRIPTION
## Context

Change the flyway configuration customizer to avoid signalling it supports events that it takes no action for. This avoids triggering a [warning](https://app.rollbar.com/a/Wise/fix/item/payin-service/45676) for services using Spring Boot 3.4 about the createSchema callback being deprecated.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
